### PR TITLE
fix: Support for videos with '/' in title

### DIFF
--- a/pkg/rutubedl/rutubedl.go
+++ b/pkg/rutubedl/rutubedl.go
@@ -318,7 +318,7 @@ func DownloadFile(fileLink string, customOutputDir *string, numWorkers int, with
 		rootOutputDir = *customOutputDir
 	}
 
-	outputFileName := filepath.Join(rootOutputDir, fmt.Sprintf("%s.mp4", video.GetTitle()))
+	outputFileName := filepath.Join(rootOutputDir, fmt.Sprintf("%s.mp4", strings.ReplaceAll(video.GetTitle(), "/", "-")))
 	tmpOutputDir := filepath.Join(rootOutputDir, video.GetID())
 	err = os.MkdirAll(tmpOutputDir, os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
This PR adds support for videos with the `/` symbol in title by replacing `/` with `-`.

For example: https://rutube.ru/video/914bf2c61bd1af4252ce22ac9980ae6d